### PR TITLE
Download and choose JDBC driver explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ install:
     --include 'presto-server-*.tar.gz' \
     --include 'presto-cli-*-executable.jar' \
     --include 'presto-product-tests-*-executable.jar' \
+    --include 'presto-jdbc-*.jar' \
+    --exclude '*-tests.jar' \
+    --exclude '*-sources.jar' \
     --no-sign-request
 - git clone --depth=50 --branch=${PRESTO_BRANCH} https://github.com/Teradata/presto.git
 - cd presto
@@ -38,6 +41,7 @@ script:
   - export PRESTO_SERVER_DIR=/tmp/presto-server-*
   - export PRESTO_CLI_JAR=/tmp/artifacts/presto-cli-*-executable.jar
   - export PRODUCT_TESTS_JAR=/tmp/artifacts/presto-product-tests-*-executable.jar
+  - export PRESTO_JDBC_DRIVER_JAR=/tmp/artifacts/presto-jdbc-*.jar
   - |
       [ ! $PRODUCT_TESTS == 'bulk' ] || \
         ./presto-product-tests/bin/run_on_docker.sh multinode -x quarantine,big_query,profile_specific_tests


### PR DESCRIPTION
this is needed, because - since it became configurable -
JDBC driver defaults to a jar in one of the target dirs.
