### PR TITLE
Use older Travis image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: java
 
 dist: trusty
-# Stick to the previous image version untill the performance regression
-# introduced with https://docs.travis-ci.com/user/build-environment-updates/2016-12-01/
-# is fixed by Travis, or we make tpcds.q14_1 pass in reasonalbe time again ourselves.
-# The regression can be considered as fixed when q14_1 passes in around 6 minutes here:
-# https://travis-ci.org/ArturGajowy/presto-checks/builds/185624131
-group: deprecated
+# Use previous images because the current ones cause timeouts
+# https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch 
+group: deprecated-2017Q2
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,17 @@ matrix:
       - PRODUCT_TESTS='-g hdfs_impersonation'
       - CLUSTER_TYPE='singlenode-hdfs-impersonation'
     - env:
+      - PRODUCT_TESTS='-g hdfs_impersonation,authorization,storage_formats,cli'
+      - CLUSTER_TYPE='singlenode-kerberos-hdfs-impersonation'
+    - env:
+      - PRODUCT_TESTS='-g hdfs_no_impersonation,storage_formats,cli'
+      - CLUSTER_TYPE='singlenode-kerberos-hdfs-no-impersonation'
+    - env:
       - PRODUCT_TESTS='-g ldap_cli'
       - CLUSTER_TYPE='singlenode-ldap'
+    - env:
+      - MVN_TESTS='-Dtest=TestLocalBinarySpilledQueries,TestPostgreSqlDistributedQueries,TestMySqlDistributedQueries'
+      - MVN_MODULES='-pl presto-tests,presto-mysql,presto-postgresql'
 
 # The whole section is reserved for overriding by cron-ed API calls.
 # Partial overrides are impossible. See https://docs.travis-ci.com/user/triggering-builds.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ services:
 
 env:
   global:
+    - DOCKER_IMAGES_VERSION=latest
+    - HADOOP_MASTER_IMAGE='teradatalabs/cdh5-hive:latest'
     - MAVEN_OPTS="-Xmx512M -XX:+ExitOnOutOfMemoryError"
     - MAVEN_SKIP_CHECKS_AND_DOCS="-Dair.check.skip-all=true -Dmaven.javadoc.skip=true"
     - MAVEN_FAST_INSTALL="-DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,38 +23,39 @@ env:
     - MAVEN_OPTS="-Xmx512M -XX:+ExitOnOutOfMemoryError"
     - MAVEN_SKIP_CHECKS_AND_DOCS="-Dair.check.skip-all=true -Dmaven.javadoc.skip=true"
     - MAVEN_FAST_INSTALL="-DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1"
+    - DISTRO_SKIP_GROUP=skip_on_cdh
 
 matrix:
   include:
     - env:
-      - PRODUCT_TESTS='-g tpcds -x quarantine -t q0,q1'
+      - PRODUCT_TESTS='-g tpcds -x quarantine,$DISTRO_SKIP_GROUP -t q0,q1'
       - CLUSTER_TYPE='singlenode'
     - env:
-      - PRODUCT_TESTS='-g tpcds -x quarantine -t q2,q3,q4'
+      - PRODUCT_TESTS='-g tpcds -x quarantine,$DISTRO_SKIP_GROUP -t q2,q3,q4'
       - CLUSTER_TYPE='singlenode'
     - env:
-      - PRODUCT_TESTS='-g tpcds -x quarantine -t q5,q6,q9'
+      - PRODUCT_TESTS='-g tpcds -x quarantine,$DISTRO_SKIP_GROUP -t q5,q6,q9'
       - CLUSTER_TYPE='singlenode'
     - env:
-      - PRODUCT_TESTS='-g tpcds -x quarantine -t q7,q8'
+      - PRODUCT_TESTS='-g tpcds -x quarantine,$DISTRO_SKIP_GROUP -t q7,q8'
       - CLUSTER_TYPE='singlenode'
     - env:
-      - PRODUCT_TESTS='-x quarantine,big_query,profile_specific_tests,tpcds'
+      - PRODUCT_TESTS='-x quarantine,big_query,profile_specific_tests,tpcds,$DISTRO_SKIP_GROUP'
       - CLUSTER_TYPE='singlenode'
     - env:
-      - PRODUCT_TESTS='-g big_query,hdfs_no_impersonation -x tpcds'
+      - PRODUCT_TESTS='-g big_query,hdfs_no_impersonation -x tpcds,$DISTRO_SKIP_GROUP'
       - CLUSTER_TYPE='singlenode'
     - env:
-      - PRODUCT_TESTS='-g hdfs_impersonation'
+      - PRODUCT_TESTS='-g hdfs_impersonation -x $DISTRO_SKIP_GROUP'
       - CLUSTER_TYPE='singlenode-hdfs-impersonation'
     - env:
-      - PRODUCT_TESTS='-g hdfs_impersonation,authorization,storage_formats,cli'
+      - PRODUCT_TESTS='-g hdfs_impersonation,authorization,storage_formats,cli -x $DISTRO_SKIP_GROUP'
       - CLUSTER_TYPE='singlenode-kerberos-hdfs-impersonation'
     - env:
-      - PRODUCT_TESTS='-g hdfs_no_impersonation,storage_formats,cli'
+      - PRODUCT_TESTS='-g hdfs_no_impersonation,storage_formats,cli -x $DISTRO_SKIP_GROUP'
       - CLUSTER_TYPE='singlenode-kerberos-hdfs-no-impersonation'
     - env:
-      - PRODUCT_TESTS='-g ldap_cli'
+      - PRODUCT_TESTS='-g ldap_cli -x $DISTRO_SKIP_GROUP'
       - CLUSTER_TYPE='singlenode-ldap'
     - env:
       - MVN_TESTS='-Dtest=TestLocalBinarySpilledQueries,TestPostgreSqlDistributedQueries,TestMySqlDistributedQueries'


### PR DESCRIPTION
The Travis builds hang on TestHiveTableStatistics, among others, with the new images.

https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch